### PR TITLE
Update get-tenantHostGroupDetail.ps1

### DIFF
--- a/get-tenantHostGroupDetail.ps1
+++ b/get-tenantHostGroupDetail.ps1
@@ -224,7 +224,7 @@ if ($summary) {
             $mr['noHostGroup'] = ($_.Group.consumedHostUnits | Measure-Object -Sum).sum
         }
     } {$mr}
-    return $summaryout
+    return $summaryout | Format-Table Name, Value -AutoSize
 } else {
     return $hostInfo
 }


### PR DESCRIPTION
When using summary mode, auto format column width. Useful for long host groups